### PR TITLE
Fixed syntax error in index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -139,7 +139,7 @@ class PackeryComponent extends Component{
     this._timer = setTimeout(() => {
         this.packery.reloadItems()
         this.packery.layout()
-    }
+    })
   }
 
   componentWillUnmount = () => {


### PR DESCRIPTION
Added missing parenthesis in index.js.

Given the code currently doesn't transpile... are you using something else instead of this project? If so, care to share?